### PR TITLE
fix: default config and branch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,10 @@ async fn pull_request(_event: PullRequestEventType, body: Json<PullRequestEvent>
 
     // Parse the config file into Cocogitto `Settings` (falling
     // back to the default if the target repo doesn't have a `cog.toml`)
-    let cog_config = Settings::try_from(cog_file).unwrap_or_else(|_| Settings::default());
+    let cog_config = Settings::try_from(cog_file).unwrap_or_else(|_| Settings {
+        ignore_merge_commits: true,
+        ..Settings::default()
+    });
 
     // Turn them into conventional commits report
     let reports: Vec<CommitReport> = commits

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn pull_request(_event: PullRequestEventType, body: Json<PullRequestEvent>
         .await
         .ok()
         .and_then(|mut content| content.take_items().into_iter().next())
-        .and_then(|cog| cog.content)
+        .and_then(|cog| cog.decoded_content())
         .unwrap_or("".to_string());
 
     // Parse the config file into Cocogitto `Settings` (falling

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn pull_request(_event: PullRequestEventType, body: Json<PullRequestEvent>
         .repos(owner, repo)
         .get_content()
         .path("cog.toml")
-        .r#ref("main")
+        .r#ref(&event.repository.default_branch)
         .send()
         .await
         .ok()

--- a/src/model/github_event/pull_request_event.rs
+++ b/src/model/github_event/pull_request_event.rs
@@ -38,6 +38,7 @@ pub enum PullRequestAction {
 pub struct PullRequestRepository {
     pub name: String,
     pub owner: PullRequestOwner,
+    pub default_branch: String,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
PR fixes oversights made in a previous PR, specifically _not_ defaulting to ignoring merge commits unless otherwise specified and hard coding "main" as the target reference when checking for the existence of `cog.toml`.